### PR TITLE
NFS PV, PVC and related deployment yaml changes

### DIFF
--- a/glance/templates/service-api.yaml
+++ b/glance/templates/service-api.yaml
@@ -12,7 +12,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */}}
 
-{{- if .Values.manifests.service_api }}
+{{- if .Values.manifests.service_datamover_api }}
 {{- $envAll := . }}
 ---
 apiVersion: v1

--- a/triliovault/templates/configmap-etc-datamover.yaml
+++ b/triliovault/templates/configmap-etc-datamover.yaml
@@ -121,8 +121,13 @@ limitations under the License.
 {{- $_ := set .Values.conf.datamover.DEFAULT "vault_storage_type" .Values.conf.triliovault.backup_target_type -}}
 {{- end -}}
 
+
 {{- if eq .Values.conf.triliovault.backup_target_type "nfs" -}}
-{{- $_ := .Values.conf.triliovault.nfs.nfs_shares | join "," | quote | set .Values.conf.datamover.DEFAULT "vault_storage_nfs_export" -}}
+{{- range $share := .Values.conf.triliovault.nfs_shares }}
+{{- range $ip, $label := . }}
+{{- $_ :=  printf "%s:%s" $ip $share | quote | set .Values.conf.datamover.DEFAULT "vault_storage_nfs_export" -}}
+{{ end }}
+{{ end }}
 {{- else -}}
 {{- $_ := set .Values.conf.datamover.DEFAULT "vault_storage_nfs_export" "TrilioVault" -}}
 {{- end -}}

--- a/triliovault/templates/configmap-etc-wlm.yaml
+++ b/triliovault/templates/configmap-etc-wlm.yaml
@@ -167,11 +167,11 @@ limitations under the License.
 
 
 {{- if empty .Values.conf.wlm.DEFAULT.keystone_endpoint_url -}}
-{{- $_ := tuple "identity" .Values.conf.wlm.clients.endpoint_type "api" . | include "helm-toolkit.endpoints.keystone_endpoint_uri_lookup" | set .Values.conf.wlm.DEFAULT "keystone_endpoint_url" -}}
+{{- $_ := tuple "identity" .Values.conf.triliovault.interface "api" . | include "helm-toolkit.endpoints.keystone_endpoint_uri_lookup" | set .Values.conf.wlm.DEFAULT "keystone_endpoint_url" -}}
 {{- end -}}
 
 {{- if empty .Values.conf.wlm.DEFAULT.nova_production_endpoint_template -}}
-{{- $_ := tuple "compute" .Values.conf.wlm.clients.endpoint_type "api" . | include "helm-toolkit.endpoints.keystone_endpoint_uri_lookup" | set .Values.conf.wlm.DEFAULT "nova_production_endpoint_template" -}}
+{{- $_ := tuple "compute" .Values.conf.triliovault.interface "api" . | include "helm-toolkit.endpoints.keystone_endpoint_uri_lookup" | set .Values.conf.wlm.DEFAULT "nova_production_endpoint_template" -}}
 {{- end -}}
 
 {{- if empty .Values.conf.wlm.DEFAULT.nova_admin_auth_url -}}
@@ -180,11 +180,11 @@ limitations under the License.
 
 
 {{- if empty .Values.conf.wlm.DEFAULT.cinder_production_endpoint_template -}}
-{{- $_ := tuple "volumev3" .Values.conf.wlm.clients.endpoint_type "api" . | include "helm-toolkit.endpoints.keystone_endpoint_uri_lookup" | set .Values.conf.wlm.DEFAULT "cinder_production_endpoint_template" -}}
+{{- $_ := tuple "volumev3" .Values.conf.triliovault.interface "api" . | include "helm-toolkit.endpoints.keystone_endpoint_uri_lookup" | set .Values.conf.wlm.DEFAULT "cinder_production_endpoint_template" -}}
 {{- end -}}
 
 {{- if empty .Values.conf.wlm.DEFAULT.neutron_production_url -}}
-{{- $_ := tuple "network" .Values.conf.wlm.clients.endpoint_type "api" . | include "helm-toolkit.endpoints.keystone_endpoint_uri_lookup" | set .Values.conf.wlm.DEFAULT "neutron_production_url" -}}
+{{- $_ := tuple "network" .Values.conf.triliovault.interface "api" . | include "helm-toolkit.endpoints.keystone_endpoint_uri_lookup" | set .Values.conf.wlm.DEFAULT "neutron_production_url" -}}
 {{- end -}}
 
 {{- if empty .Values.conf.wlm.DEFAULT.neutron_admin_auth_url -}}
@@ -192,11 +192,11 @@ limitations under the License.
 {{- end -}}
 
 {{- if empty .Values.conf.wlm.DEFAULT.glance_production_api_servers -}}
-{{- $_ := tuple "image" .Values.conf.wlm.clients.endpoint_type "api" . | include "helm-toolkit.endpoints.keystone_endpoint_uri_lookup" | set .Values.conf.wlm.DEFAULT "glance_production_api_servers" -}}
+{{- $_ := tuple "image" .Values.conf.triliovault.interface "api" . | include "helm-toolkit.endpoints.keystone_endpoint_uri_lookup" | set .Values.conf.wlm.DEFAULT "glance_production_api_servers" -}}
 {{- end -}}
 
 {{- if empty .Values.conf.wlm.DEFAULT.glance_production_host -}}
-{{- $_ := tuple "image" .Values.conf.wlm.clients.endpoint_type . | include "helm-toolkit.endpoints.endpoint_host_lookup" | set .Values.conf.wlm.DEFAULT "glance_production_host" -}}
+{{- $_ := tuple "image" .Values.conf.triliovault.interface . | include "helm-toolkit.endpoints.endpoint_host_lookup" | set .Values.conf.wlm.DEFAULT "glance_production_host" -}}
 {{- end -}}
 
 {{- if empty .Values.conf.wlm.DEFAULT.domain_name -}}
@@ -204,8 +204,9 @@ limitations under the License.
 {{- end -}}
 
 
-
-
+{{- if empty .Values.conf.wlm.clients.endpoint_type -}}
+{{- $_ := set .Values.conf.wlm.clients "endpoint_type " .Values.conf.triliovault.interface  -}}
+{{- end -}}
 
 
 {{- if empty .Values.conf.wlm.alembic.sqlalchemy.url -}}
@@ -216,6 +217,31 @@ limitations under the License.
 {{- if empty .Values.conf.wlm.DEFAULT.region_name_for_services -}}
 {{- $_ := set .Values.conf.wlm.DEFAULT "region_name_for_services" .Values.endpoints.identity.auth.admin.region_name -}}
 {{- end -}}
+
+
+{{/* **********************************************************************
+     set api-paste.ini conf parameters
+     **********************************************************************
+*/}}
+
+{{- if empty .Values.conf.paste.filter:authtoken.auth_host -}}
+{{- $_ := tuple "identity" .Values.conf.triliovault.interface . | include "helm-toolkit.endpoints.endpoint_host_lookup" | set .Values.conf.paste.filter:authtoken "auth_host" -}}
+{{- end -}}
+
+{{- if empty .Values.conf.paste.filter:authtoken.auth_port -}}
+{{- $_ := tuple "identity" .Values.conf.triliovault.interface "api" . | include "helm-toolkit.endpoints.endpoint_port_lookup" | set .Values.conf.paste.filter:authtoken "auth_port" -}}
+{{- end -}}
+
+
+{{- if empty .Values.conf.paste.filter:authtoken.auth_protocol -}}
+{{- $_ := tuple "identity" .Values.conf.triliovault.interface "api" . | include "helm-toolkit.endpoints.endpoint_port_lookup" | set .Values.conf.paste.filter:authtoken "auth_protocol" -}}
+{{- end -}}
+
+
+{{- if empty .Values.conf.paste.filter:authtoken.interface -}}
+{{- $_ := set .Values.conf.wlm.filter:authtoken "interface" .Values.conf.triliovault.interface -}}
+{{- end -}}
+
 
 
 {{/* **********************************************************************

--- a/triliovault/templates/configmap-etc-wlm.yaml
+++ b/triliovault/templates/configmap-etc-wlm.yaml
@@ -109,10 +109,15 @@ limitations under the License.
 {{- $_ := set .Values.conf.wlmr.DEFAULT "vault_storage_type" .Values.conf.triliovault.backup_target_type -}}
 {{- end -}}
 
+
 {{- if eq .Values.conf.triliovault.backup_target_type "nfs" -}}
-{{- $_ := .Values.conf.triliovault.nfs.nfs_shares | join "," | quote | set .Values.conf.wlm.DEFAULT "vault_storage_nfs_export" -}}
+{{- range $share := .Values.conf.triliovault.nfs_shares }}
+{{- range $ip, $label := . }}
+{{- $_ :=  printf "%s:%s" $ip $share | quote | set .Values.conf.wlm.DEFAULT "vault_storage_nfs_export" -}}
+{{ end }}
+{{ end }}
 {{- else -}}
-{{- $_ := set .Values.conf.wlm.DEFAULT "vault_storage_nfs_export" "TrilioVault" -}}
+{{- $_ := set .Values.conf.datamover.DEFAULT "vault_storage_nfs_export" "TrilioVault" -}}
 {{- end -}}
 
 {{- if empty .Values.conf.wlm.DEFAULT.vault_storage_nfs_options -}}

--- a/triliovault/templates/daemonset-datamover.yaml
+++ b/triliovault/templates/daemonset-datamover.yaml
@@ -20,11 +20,22 @@ limitations under the License.
 
 {{- $serviceAccountName := "triliovault-datamover" }}
 {{ tuple $envAll "datamover" $serviceAccountName | include "helm-toolkit.snippets.kubernetes_pod_rbac_serviceaccount" }}
+
+{{- if eq .Values.conf.triliovault.backup_target_type "nfs" -}}
+{{- $share_path := index .Values.conf.triliovault.nfs.nfs_shares 0 "path" -}}
+{{- $share_ip := index .Values.conf.triliovault.nfs.nfs_shares 0 "ip" -}}
+{{- $node_selector_key := index .Values.conf.triliovault.nfs.nfs_shares 0 "node_selector_key" -}}
+{{- $node_selector_value := index .Values.conf.triliovault.nfs.nfs_shares 0 "node_selector_value" -}}
+{{- $nfs_mount_point_endcoded := $share_path | b64enc }}
+{{- $nfs_mount_point := printf "%s/%s" .Values.conf.datamover.DEFAULT.vault_data_directory $nfs_mount_point_endcoded }}
+{{- end -}}
+
+
 ---
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
-  name: triliovault-datamover
+  name: triliovault-datamover-{{ $node_selector_key }}
   annotations:
     {{ tuple $envAll | include "helm-toolkit.snippets.release_uuid" }}
   labels:
@@ -52,7 +63,7 @@ spec:
       hostIPC: true
       dnsPolicy: ClusterFirstWithHostNet
       nodeSelector:
-        {{ .Values.labels.datamover.node_selector_key }}: {{ .Values.labels.datamover.node_selector_value }}
+        {{ $node_selector_key }}: {{ $node_selector_value }}
       initContainers:
 {{ tuple $envAll "datamover" $mounts_triliovault_datamover_init | include "helm-toolkit.snippets.kubernetes_entrypoint_init_container" | indent 8 }}
       containers:
@@ -126,6 +137,10 @@ spec:
             - name: dev
               mountPath: /dev
               mountPropagation: HostToContainer
+            {{- if eq .Values.conf.triliovault.backup_target_type "nfs" }}
+            - name: triliovault-nfs-pv-{{ $share_ip}}-{{ $share_path }}
+              mountPath: {{ $nfs_mount_point | quote }}
+            {{- end }}
 {{ if $mounts_triliovault_datamover.volumeMounts }}{{ toYaml $mounts_triliovault_datamover.volumeMounts | indent 12 }}{{ end }}
       volumes:
         - name: pod-tmp
@@ -168,5 +183,10 @@ spec:
         - name: dev
           hostPath:
             path: /dev
+        {{- if eq .Values.conf.triliovault.backup_target_type "nfs" }}
+        - name: triliovault-nfs-pv-{{ $share_ip}}-{{ $share_path }}
+          persistentVolumeClaim:
+            claimName: triliovault-nfs-pvc-{{ $share_ip}}-{{ $share_path }}
+        {{- end }}
 {{ if $mounts_triliovault_datamover.volumes }}{{ toYaml $mounts_triliovault_datamover.volumes | indent 8 }}{{ end }}
 {{- end }}

--- a/triliovault/templates/deployment-wlm-workloads.yaml
+++ b/triliovault/templates/deployment-wlm-workloads.yaml
@@ -20,6 +20,18 @@ limitations under the License.
 
 {{- $serviceAccountName := "triliovault-wlm-workloads" }}
 {{ tuple $envAll "wlm_workloads" $serviceAccountName | include "helm-toolkit.snippets.kubernetes_pod_rbac_serviceaccount" }}
+
+{{- if eq .Values.conf.triliovault.backup_target_type "nfs" -}}
+{{- $share_path := index .Values.conf.triliovault.nfs.nfs_shares 0 "path" -}}
+{{- $share_ip := index .Values.conf.triliovault.nfs.nfs_shares 0 "ip" -}}
+{{- $node_selector_key := index .Values.conf.triliovault.nfs.nfs_shares 0 "node_selector_key" -}}
+{{- $node_selector_value := index .Values.conf.triliovault.nfs.nfs_shares 0 "node_selector_value" -}}
+{{- $nfs_mount_point_endcoded := $share_path | b64enc }}
+{{- $nfs_mount_point := printf "%s/%s" .Values.conf.datamover.DEFAULT.vault_data_directory $nfs_mount_point_endcoded }}
+{{- end -}}
+
+
+
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -100,6 +112,10 @@ spec:
               mountPath: /tmp/triliovault-wlm-workloads.sh
               subPath: triliovault-wlm-workloads.sh
               readOnly: true
+            {{- if eq .Values.conf.triliovault.backup_target_type "nfs" }}
+            - name: triliovault-nfs-pv-{{ $share_ip}}-{{ $share_path }}
+              mountPath: {{ $nfs_mount_point | quote }}
+            {{- end }}
 {{ if $mounts_triliovault_wlm_workloads.volumeMounts }}{{ toYaml $mounts_triliovault_wlm_workloads.volumeMounts | indent 12 }}{{ end }}
       volumes:
         - name: pod-tmp
@@ -114,5 +130,10 @@ spec:
           configMap:
             name: triliovault-wlm-bin
             defaultMode: 0555
+        {{- if eq .Values.conf.triliovault.backup_target_type "nfs" }}
+        - name: triliovault-nfs-pv-{{ $share_ip}}-{{ $share_path }}
+          persistentVolumeClaim:
+            claimName: triliovault-nfs-pvc-{{ $share_ip}}-{{ $share_path }}
+        {{- end }}
 {{ if $mounts_triliovault_wlm_workloads.volumes }}{{ toYaml $mounts_triliovault_wlm_workloads.volumes | indent 8 }}{{ end }}
 {{- end }}

--- a/triliovault/templates/network_policy_datamover.yaml
+++ b/triliovault/templates/network_policy_datamover.yaml
@@ -12,13 +12,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */}}
 
-{{- if .Values.manifests.network_policy -}}
-{{- $opts := dict "envAll" . "name" "application" "label" "triliovault" -}}
+{{- if .Values.manifests.network_policy_datamover -}}
+{{- $opts := dict "envAll" . "name" "application" "label" "triliovault-datamover" -}}
 {{ $opts | include "helm-toolkit.manifests.kubernetes_network_policy" }}
-{{- end -}}
-
-
-{{- if .Values.manifests.network_policy -}}
-{{- $netpol_opts := dict "envAll" . "name" "application" "label" "glance" -}}
-{{ $netpol_opts | include "helm-toolkit.manifests.kubernetes_network_policy" }}
 {{- end -}}

--- a/triliovault/templates/network_policy_wlm.yaml
+++ b/triliovault/templates/network_policy_wlm.yaml
@@ -3,7 +3,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-   http://www.apache.org/licenses/LICENSE-2.0
+    http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -12,7 +12,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */}}
 
-{{- if and .Values.manifests.service_ingress_wlm_pi .Values.network.wlm_api.ingress.public }}
-{{- $serviceIngressOpts := dict "envAll" . "backendServiceType" "workloads" -}}
-{{ $serviceIngressOpts | include "helm-toolkit.manifests.service_ingress" }}
-{{- end }}
+{{- if .Values.manifests.network_policy_wlm -}}
+{{- $opts := dict "envAll" . "name" "application" "label" "triliovault-wlm" -}}
+{{ $opts | include "helm-toolkit.manifests.kubernetes_network_policy" }}
+{{- end -}}

--- a/triliovault/templates/nfs-pv.yaml
+++ b/triliovault/templates/nfs-pv.yaml
@@ -1,0 +1,42 @@
+{{/*
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/}}
+
+{{- if .Values.manifests.nfs_pv -}}
+{{- if eq .Values.conf.triliovault.backup_target_type "nfs" -}}
+{{- $share_path := index .Values.conf.triliovault.nfs.nfs_shares 0 "path" -}}
+{{- $share_ip := index .Values.conf.triliovault.nfs.nfs_shares 0 "ip" -}}
+
+---
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: triliovault-nfs-pv-{{ $share_ip}}-{{ $share_path }}
+  labels:
+{{ tuple $envAll "triliovault" "datamover" | include "helm-toolkit.snippets.kubernetes_metadata_labels" | indent 4 }}
+spec:
+  capacity:
+    storage: 20Gi
+  volumeMode: Filesystem
+  accessModes:
+    - ReadWriteMany
+  persistentVolumeReclaimPolicy: Retain
+  storageClassName: nfs
+  mountOptions: 
+{{ .Values.conf.triliovault.nfs.nfs_options -1 | regexSplit "," | toYaml | indent 4 }}
+  nfs:
+    path: {{ $share_path }}
+    server: {{ $share_ip }}
+
+{{- end -}}
+{{- end -}}

--- a/triliovault/templates/nfs-pvc.yaml
+++ b/triliovault/templates/nfs-pvc.yaml
@@ -24,6 +24,7 @@ apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
   name: triliovault-nfs-pvc-{{ $share_ip}}-{{ $share_path }}
+{{ tuple $envAll "triliovault" "datamover" | include "helm-toolkit.snippets.kubernetes_metadata_labels" | indent 4 }}
 spec:
   storageClassName: nfs
   accessModes:

--- a/triliovault/templates/nfs-pvc.yaml
+++ b/triliovault/templates/nfs-pvc.yaml
@@ -1,0 +1,36 @@
+{{/*
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/}}
+
+
+{{- if .Values.manifests.nfs_pvc -}}
+{{- if eq .Values.conf.triliovault.backup_target_type "nfs" -}}
+{{- $share_path := index .Values.conf.triliovault.nfs.nfs_shares 0 "path" -}}
+{{- $share_ip := index .Values.conf.triliovault.nfs.nfs_shares 0 "ip" -}}
+
+
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: triliovault-nfs-pvc-{{ $share_ip}}-{{ $share_path }}
+spec:
+  storageClassName: nfs
+  accessModes:
+    - ReadWriteMany
+  resources:
+    requests:
+      storage: 20Gi
+
+{{- end -}}
+{{- end -}}

--- a/triliovault/templates/secret-datamover-ingress-tls.yaml
+++ b/triliovault/templates/secret-datamover-ingress-tls.yaml
@@ -12,7 +12,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */}}
 
-{{- if .Values.manifests.secret_ingress_tls }}
+{{- if .Values.manifests.secret_ingress_tls_datamover }}
 {{- include "helm-toolkit.manifests.secret_ingress_tls" ( dict "envAll" . "backendServiceType" "datamover" ) }}
-{{- include "helm-toolkit.manifests.secret_ingress_tls" ( dict "envAll" . "backendServiceType" "workloads" ) }}
 {{- end }}

--- a/triliovault/templates/secret-wlm-ingress-tls.yaml
+++ b/triliovault/templates/secret-wlm-ingress-tls.yaml
@@ -12,7 +12,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */}}
 
-{{- if .Values.manifests.secret_ingress_tls }}
-{{- include "helm-toolkit.manifests.secret_ingress_tls" ( dict "envAll" . "backendServiceType" "datamover" ) }}
+{{- if .Values.manifests.secret_ingress_tls_wlm }}
 {{- include "helm-toolkit.manifests.secret_ingress_tls" ( dict "envAll" . "backendServiceType" "workloads" ) }}
 {{- end }}

--- a/triliovault/templates/service-datamover-api.yaml
+++ b/triliovault/templates/service-datamover-api.yaml
@@ -12,7 +12,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */}}
 
-{{- if .Values.manifests.service_api }}
+{{- if .Values.manifests.service_datamover_api }}
 {{- $envAll := . }}
 ---
 apiVersion: v1
@@ -21,16 +21,16 @@ metadata:
   name: {{ tuple "datamover" "internal" . | include "helm-toolkit.endpoints.hostname_short_endpoint_lookup" }}
 spec:
   ports:
-    - name: t-api
+    - name: d-api
       port: {{ tuple "datamover" "internal" "api" . | include "helm-toolkit.endpoints.endpoint_port_lookup" }}
-      {{ if .Values.network.api.node_port.enabled }}
+      {{ if .Values.network.datamover_api.node_port.enabled }}
       nodePort: {{ .Values.network.api.node_port.port }}
       {{ end }}
   selector:
-{{ tuple $envAll "tvault" "api" | include "helm-toolkit.snippets.kubernetes_metadata_labels" | indent 4 }}
-  {{ if .Values.network.api.node_port.enabled }}
+{{ tuple $envAll "triliovault" "datamover-api" | include "helm-toolkit.snippets.kubernetes_metadata_labels" | indent 4 }}
+  {{ if .Values.network.datamover_api.node_port.enabled }}
   type: NodePort
-  {{ if .Values.network.api.external_policy_local }}
+  {{ if .Values.network.datamover_api.external_policy_local }}
   externalTrafficPolicy: Local
   {{ end }}
   {{ end }}

--- a/triliovault/templates/service-ingress-datamover-api.yaml
+++ b/triliovault/templates/service-ingress-datamover-api.yaml
@@ -12,7 +12,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */}}
 
-{{- if and .Values.manifests.service_ingress_api .Values.network.api.ingress.public }}
+{{- if and .Values.manifests.service_ingress_datamover_api .Values.network.datamover_api.ingress.public }}
 {{- $serviceIngressOpts := dict "envAll" . "backendServiceType" "datamover" -}}
 {{ $serviceIngressOpts | include "helm-toolkit.manifests.service_ingress" }}
 {{- end }}

--- a/triliovault/templates/service-wlm-api.yaml
+++ b/triliovault/templates/service-wlm-api.yaml
@@ -12,7 +12,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */}}
 
-{{- if .Values.manifests.service_api }}
+{{- if .Values.manifests.service_wlm_api }}
 {{- $envAll := . }}
 ---
 apiVersion: v1
@@ -23,14 +23,14 @@ spec:
   ports:
     - name: w-api
       port: {{ tuple "workloads" "internal" "api" . | include "helm-toolkit.endpoints.endpoint_port_lookup" }}
-      {{ if .Values.network.api.node_port.enabled }}
+      {{ if .Values.network.wlm_api.node_port.enabled }}
       nodePort: {{ .Values.network.wlm_api.node_port.port }}
       {{ end }}
   selector:
-{{ tuple $envAll "triliovault" "wlm_api" | include "helm-toolkit.snippets.kubernetes_metadata_labels" | indent 4 }}
-  {{ if .Values.network.api.node_port.enabled }}
+{{ tuple $envAll "triliovault" "wlm-api" | include "helm-toolkit.snippets.kubernetes_metadata_labels" | indent 4 }}
+  {{ if .Values.network.wlm_api.node_port.enabled }}
   type: NodePort
-  {{ if .Values.network.api.external_policy_local }}
+  {{ if .Values.network.wlm_api.external_policy_local }}
   externalTrafficPolicy: Local
   {{ end }}
   {{ end }}

--- a/triliovault/values.yaml
+++ b/triliovault/values.yaml
@@ -658,10 +658,11 @@ conf:
     backup_target_type: "nfs"
     ## Valid values are "nfs" and "s3"
     nfs:
-      nfs_shares:
-        - /opt/share1:
-            192.168.122.101:
-              node_selector: openstack-compute-node
+      nfs_shares: 
+      - path: /opt/share1
+        ip: 192.168.122.101
+        node_selector_key: openstack-compute-node
+        node_selector_value: enabled
       nfs_options: "nolock,soft,vers=3,timeo=180,intr,lookupcache=none"
     s3:
       access_key: ''

--- a/triliovault/values.yaml
+++ b/triliovault/values.yaml
@@ -336,16 +336,20 @@ manifests:
   triliovault_datamover_configmap_etc: true
   ingress_api: true
   job_bootstrap: true
-  pdb_api: true
+  pdb_datamover_api: true
+  pdb_wlm_api: true
   network_policy: false
   secret_db_datamover: true
   secret_db_wlm: true
-  secret_ingress_tls: true
+  secret_ingress_tls_datamover: true
+  secret_ingress_tls_wlm: true
   secret_triliovault_wlm_keystone: true
   secret_triliovault_datamover_keystone: true
   secret_rabbitmq: true
-  service_api: true
-  service_ingress_api: true
+  service_datamover_api: true
+  service_wlm_api: true
+  service_ingress_datamover_api: true
+  service_ingress_wlm_api: true
 
 network:
   wlm_api:
@@ -359,7 +363,7 @@ network:
     external_policy_local: false
     node_port:
       enabled: false
-      port: 8042
+      port: 30901
   datamover_api:
     ingress:
       public: true
@@ -371,7 +375,7 @@ network:
     external_policy_local: false
     node_port:
       enabled: false
-      port: 8042
+      port: 30902
 
 # Names of secrets used by bootstrap and environmental checks
 secrets:

--- a/triliovault/values.yaml
+++ b/triliovault/values.yaml
@@ -727,28 +727,24 @@ conf:
       paste.filter_factory: workloadmgr.api.middleware.auth:WorkloadMgrKeystoneContext.factory
     filter:authtoken:
       paste.filter_factory:  keystonemiddleware.auth_token:filter_factory
-      auth_host: <TODO>
-      auth_port: <TODO>
-      auth_protocol: <TODO>
-      admin_tenant_name: <TODO>
+      admin_tenant_name: service
       admin_user: triliovault
-      admin_password: <TODO>
+      admin_password: password
       admin_user_domain_id: <TODO>
       signing_dir: /var/cache/workloadmgr
       insecure: True
-      interface: <TODO>
   datamover_api:
     DEFAULT:
       log_config_append: /etc/triliovault-datamover/logging.conf
-      dmapi_link_prefix: http://{{ api_interface_address }}:8784
+      dmapi_link_prefix: http://{{ api_interface_address }}:8784 <TODO>
       ## Don't delete this parameter. Keep it empty
       dmapi_enabled_ssl_apis: ""
       dmapi_listen_port: 8784
       dmapi_enabled_apis: dmapi
       bindir: /usr/bin
       instance_name_template: instance-%08x
-      dmapi_listen: {{ api_interface_address }}
-      my_ip: {{ api_interface_address }}
+      dmapi_listen: {{ api_interface_address }} <TODO>
+      my_ip: {{ api_interface_address }} <TODO>
       rootwrap_config: /etc/triliovault-datamover/rootwrap.conf
       debug: False
     wsgi:
@@ -815,11 +811,11 @@ conf:
       triliovault_hostnames: ""
       api_paste_config: /etc/triliovault-wlm/api-paste.ini
       rootwrap_config: /etc/triliovault-wlm/rootwrap.conf
-	    cloud_admin_user_id: ""
-      cloud_admin_domain: ""
-      cloud_admin_project_id: ""
+	    cloud_admin_user_id: <TODO>
+      cloud_admin_domain: <TODO>
+      cloud_admin_project_id: <TODO>
       cloud_admin_role: admin
-      cloud_unique_id: <TODO: Set in config_etc>
+      cloud_unique_id: <TODO: Set in config_etc> triliovault user id
       compute_driver: libvirt.LibvirtDriver
       config_status: configured
       verbose: True
@@ -843,7 +839,6 @@ conf:
     clients:
       client_retry_limit: 3
       insecure: False
-      endpoint_type: internal
     global_job_scheduler:
       misfire_grace_time: 600
     keystone_authtoken:

--- a/triliovault/values.yaml
+++ b/triliovault/values.yaml
@@ -350,6 +350,8 @@ manifests:
   service_wlm_api: true
   service_ingress_datamover_api: true
   service_ingress_wlm_api: true
+  nfs_pv: true
+  nfs_pvc: true
 
 network:
   wlm_api:
@@ -659,14 +661,7 @@ conf:
       nfs_shares:
         - /opt/share1:
             192.168.122.101:
-              node_selector: kubernetes_node_label1
-            192.168.122.102:
-              node_selector: kubernetes_node_label2
-        - /opt/share2:
-            192.168.122.201:
-              node_selector: kubernetes_node_label1
-            192.168.122.202:
-              node_selector: kubernetes_node_label2
+              node_selector: openstack-compute-node
       nfs_options: "nolock,soft,vers=3,timeo=180,intr,lookupcache=none"
     s3:
       access_key: ''

--- a/triliovault/values_overrides/conf_triliovault.yaml
+++ b/triliovault/values_overrides/conf_triliovault.yaml
@@ -3,17 +3,11 @@ conf:
     ## Valid values are "nfs" and "s3"
     backup_target_type: "nfs"
     nfs:
-      nfs_shares:
-        - /opt/share1:
-            192.168.122.101:
-              node_selector: kubernetes_node_label1
-            192.168.122.102:
-              node_selector: kubernetes_node_label2
-        - /opt/share2:
-            192.168.122.201:
-              node_selector: kubernetes_node_label1
-            192.168.122.202:
-              node_selector: kubernetes_node_label2
+      nfs_shares: 
+      - path: /opt/share1
+        ip: 192.168.122.101
+        node_selector_key: openstack-compute-node
+        node_selector_value: enabled
       nfs_options: "nolock,soft,vers=3,timeo=180,intr,lookupcache=none"
     s3:
       access_key: ''

--- a/triliovault/values_overrides/conf_triliovault.yaml
+++ b/triliovault/values_overrides/conf_triliovault.yaml
@@ -29,6 +29,17 @@ conf:
     ## If your dmapi node has ‘n' cpu cores, It is recommended, to set this parameter to '4*n’.
     ## If dmapi_workers field is not present in config file. The Default value will be equals to number of cores present on the node
     datamover_api_workers: 16
+
+    cloud_admin_user_name: ""
+    cloud_admin_project_name: ""
+    ## Provide any role name as your preference. 
+    ## Significance: To run any backups in triliovault an openstack user needs to have this role on given project. 
+    trustee_role: "creater"
+    ## Keystone endpoint interface that triliovault workloadmgr services will use to communicate to other openstack services
+    ## Valid values: internal, public, admin
+    interface: "internal"
+
+
   wlm: 
     DEFAULT:
       ## Following are cloud admin user's details


### PR DESCRIPTION
- Added nfs-pv.yaml, nfs-pvc.yaml
- Used new nfs input format. Added comment in helm chart design document: https://triliodata.atlassian.net/wiki/spaces/TVO/pages/3418914848/TVO+Helm+Chart
- Updated datamover daemonset yaml file with nfs pv as volumes, volume mount
- Updated wlm workloads yaml file with nfs pv as volumes, volume mount
- Some naming fixes in other yamls